### PR TITLE
fix: use fsPath instead of path for Windows compatibility

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -15,7 +15,7 @@ export function normalizeSchemaUrl(schemaURL: string): string {
       return url.pathToFileURL(schemaURL).toString();
     } else {
       // NOT a full URL, treat as relative path
-      const basePath = activeEditor?.document.uri.path.split("/").slice(0, -1).join("/");
+      const basePath = activeEditor?.document.uri.fsPath.split(/[\\/]/).slice(0, -1).join("/");
       return url.pathToFileURL(basePath + "/" + schemaURL).toString();
     }
   }


### PR DESCRIPTION
I found the bug causing the "Could not parse the RNG Schema" error on Windows (issue #45).
The problem is in normalizeSchemaUrl in utils.ts 
It was using uri.path to build the file path, which on Windows gives a different format with a fake leading slash that the system can't understand. Switching to uri.fsPath gives the real Windows path instead.
I tested this on Mac to make sure nothing broke.